### PR TITLE
[#151322324] Checkout the TLS feature branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -129,7 +129,7 @@
 	url = https://github.com/armon/go-proxyproto.git
 [submodule "src/code.cloudfoundry.org/route-registrar"]
 	path = src/code.cloudfoundry.org/route-registrar
-	url = https://github.com/cloudfoundry-incubator/route-registrar
+	url = https://github.com/alphagov/paas-route-registrar
 [submodule "src/code.cloudfoundry.org/multierror"]
 	path = src/code.cloudfoundry.org/multierror
 	url = https://github.com/cloudfoundry/multierror


### PR DESCRIPTION
## What

We need to have a custom release pointing to the upgraded route-registrar repository, which consists of TLS upgrade as well as addition of `server_cert_domain_san` parameter to solve our deployment problems with certificate validation.

## How to review

- To be deployed with alphagov/paas-cf#1081

## Who can review

Neither @bandesz, @dcarley nor myself